### PR TITLE
[FEAT] Add PeepTextStyle and Fix PeepCategoryButton

### DIFF
--- a/lib/app/theme/text_size.dart
+++ b/lib/app/theme/text_size.dart
@@ -1,6 +1,0 @@
-class TextSize {
-  static const huge = 24.0;
-  static const large = 20.0;
-  static const normal = 16.0;
-  static const small = 14.0;
-}

--- a/lib/app/theme/text_style.dart
+++ b/lib/app/theme/text_style.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:peep_todo_flutter/app/theme/palette.dart';
+
+class PeepTextStyle {
+  static TextStyle regularXS(Color? color) {
+    return PeepTextStyleBase.baseRegularXS.copyWith(color: color ?? Palette.peepBlack);
+  }
+
+  static TextStyle regularS(Color? color) {
+    return PeepTextStyleBase.baseRegularS.copyWith(color: color ?? Palette.peepBlack);
+  }
+
+  static TextStyle regularM(Color? color) {
+    return PeepTextStyleBase.baseRegularM.copyWith(color: color ?? Palette.peepBlack);
+  }
+
+  static TextStyle regularL(Color? color) {
+    return PeepTextStyleBase.baseRegularL.copyWith(color: color ?? Palette.peepBlack);
+  }
+
+  static TextStyle regularXL(Color? color) {
+    return PeepTextStyleBase.baseRegularXL.copyWith(color: color ?? Palette.peepBlack);
+  }
+
+  static TextStyle boldXS(Color? color) {
+    return PeepTextStyleBase.baseBoldXS.copyWith(color: color ?? Palette.peepBlack);
+  }
+
+  static TextStyle boldS(Color? color) {
+    return PeepTextStyleBase.baseBoldS.copyWith(color: color ?? Palette.peepBlack);
+  }
+
+  static TextStyle boldM(Color? color) {
+    return PeepTextStyleBase.baseBoldM.copyWith(color: color ?? Palette.peepBlack);
+  }
+
+  static TextStyle boldL(Color? color) {
+    return PeepTextStyleBase.baseBoldL.copyWith(color: color ?? Palette.peepBlack);
+  }
+
+  static TextStyle boldXL(Color? color) {
+    return PeepTextStyleBase.baseBoldXL.copyWith(color: color ?? Palette.peepBlack);
+  }
+}
+
+abstract class PeepTextStyleBase {
+  static TextStyle baseRegularXS = TextStyle(
+    fontSize: 12.sp,
+    fontWeight: FontWeight.normal,
+  );
+
+  static const TextStyle baseRegularS = TextStyle(
+    fontSize: 14.0,
+    fontWeight: FontWeight.normal,
+  );
+
+  static const TextStyle baseRegularM = TextStyle(
+    fontSize: 16.0,
+    fontWeight: FontWeight.normal,
+  );
+
+  static const TextStyle baseRegularL = TextStyle(
+    fontSize: 20.0,
+    fontWeight: FontWeight.normal,
+  );
+
+  static const TextStyle baseRegularXL = TextStyle(
+    fontSize: 24.0,
+    fontWeight: FontWeight.normal,
+  );
+
+  static TextStyle baseBoldXS = TextStyle(
+    fontSize: 12.sp,
+    fontWeight: FontWeight.bold,
+  );
+
+  static const TextStyle baseBoldS = TextStyle(
+    fontSize: 14.0,
+    fontWeight: FontWeight.bold,
+  );
+
+  static const TextStyle baseBoldM = TextStyle(
+    fontSize: 16.0,
+    fontWeight: FontWeight.bold,
+  );
+
+  static const TextStyle baseBoldL = TextStyle(
+    fontSize: 20.0,
+    fontWeight: FontWeight.bold,
+  );
+
+  static const TextStyle baseBoldXL = TextStyle(
+    fontSize: 24.0,
+    fontWeight: FontWeight.bold,
+  );
+}

--- a/lib/app/views/common/buttons/peep_category_button.dart
+++ b/lib/app/views/common/buttons/peep_category_button.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:peep_todo_flutter/app/theme/palette.dart';
-import 'package:peep_todo_flutter/app/theme/text_size.dart';
+import 'package:peep_todo_flutter/app/theme/text_style.dart';
 
 class PeepCategoryButton extends StatelessWidget {
   final Color color;
@@ -46,11 +46,7 @@ class PeepCategoryButton extends StatelessWidget {
                   // Category Name
                   Text(
                     name,
-                    style: TextStyle(
-                        color: color,
-                        fontSize: TextSize.small,
-                        fontWeight: FontWeight.bold),
-                  ),
+                    style: PeepTextStyle.boldS(color)),
                 ],
               ),
               SizedBox(


### PR DESCRIPTION
## 한 일
TextStyle을 구현했습니다. TSK #이 없으므로 prefix는 FEAT으로 두었습니다.

## 할 일
### PeepTextStyle 사용법
- Text("", style : PeepTextStyle.regularM());
다음과 같이 사용하면 됩니다. 괄호 안에 들어가는 파라미터는 Color입니다. null인 경우 PeepBlack입니다.

## 장애물
X